### PR TITLE
Use kernel .tar.gz file from cache

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.tar.gz filter=lfs diff=lfs merge=lfs -text
+*.tar.gz  diff=tar-gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,12 +34,29 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          lfs: "true"
           fetch-depth: 0
+      - name: Extract kernel download URL
+        id: get-kernel-url
+        run: |
+          KERNEL_URL="$(cat firmware/${{ matrix.firmware }}/kernel-url.txt | tr -d '\n')"
+          echo "kernel-url=${KERNEL_URL}" >> $GITHUB_OUTPUT
+          echo "kernel-url-b64=$(echo ${KERNEL_URL} | base64 -w0)" >> $GITHUB_OUTPUT
+      - name: Restore kernel archive from cache
+        id: cache-kernel-archive
+        uses: actions/cache@v3
+        with:
+          path: ./linux-udr.tar.gz
+          key: ${{ steps.get-kernel-url.outputs.kernel-url-b64 }}
+      - name: Download kernel archive if required
+        if: steps.cache-kernel-archive.outputs.cache-hit != 'true'
+        run: |
+          curl -Lo ./linux-udr.tar.gz "${{ steps.get-kernel-url.outputs.kernel-url }}"
+      - name: Ensure kernel SHA matches
+        run: sha256sum -c firmware/${{ matrix.firmware }}/linux-udr.tar.gz.sum
       - name: Extract Kernel
         run: |
           mkdir linux-source
-          tar -xf firmware/${{ matrix.firmware }}/linux-udr.tar.gz --strip-components=1 -C linux-source
+          tar -xf ./linux-udr.tar.gz --strip-components=1 -C linux-source
       - name: Copy kernel config file into kernel directory
         run: cp firmware/${{ matrix.firmware }}/kernel-config linux-source/.config
       - name: Update git tag placeholder in any patches

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 modules/
 text_files_out/
+linux-udr.tar.gz

--- a/firmware/2.2.12/kernel-url.txt
+++ b/firmware/2.2.12/kernel-url.txt
@@ -1,0 +1,1 @@
+https://archive.org/download/unifi-udr-gpl-archives/linux-udr-2.2.12.tar.gz

--- a/firmware/2.2.12/linux-udr.tar.gz
+++ b/firmware/2.2.12/linux-udr.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d232dec7c148a44b74e1ddfd6d336a32d4a228ee70b3dba586c3a7e43d9f31b7
-size 178055834

--- a/firmware/2.2.12/linux-udr.tar.gz.sum
+++ b/firmware/2.2.12/linux-udr.tar.gz.sum
@@ -1,0 +1,1 @@
+d232dec7c148a44b74e1ddfd6d336a32d4a228ee70b3dba586c3a7e43d9f31b7  linux-udr.tar.gz

--- a/firmware/3.0.13/kernel-url.txt
+++ b/firmware/3.0.13/kernel-url.txt
@@ -1,0 +1,1 @@
+https://archive.org/download/unifi-udr-gpl-archives/linux-udr-2.2.12.tar.gz

--- a/firmware/3.0.13/linux-udr.tar.gz
+++ b/firmware/3.0.13/linux-udr.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d232dec7c148a44b74e1ddfd6d336a32d4a228ee70b3dba586c3a7e43d9f31b7
-size 178055834

--- a/firmware/3.0.13/linux-udr.tar.gz.sum
+++ b/firmware/3.0.13/linux-udr.tar.gz.sum
@@ -1,0 +1,1 @@
+d232dec7c148a44b74e1ddfd6d336a32d4a228ee70b3dba586c3a7e43d9f31b7  linux-udr.tar.gz


### PR DESCRIPTION
No longer using LFS for this, as I immediately hit my account limit.

If not currently cached, download from url specified in txt file in each firmware directory.

I plan to cache the GPL dumps from ubiquiti on archive.org to ensure that they aren't lost down the line.